### PR TITLE
Now works over HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 
     <title>NYC Felonies Map</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/themes/css/cartodb.css" />
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
 
     <link rel="icon" type="image/png" href="./favicon.png">
@@ -137,7 +137,7 @@ WITH q AS (SELECT cartodb_id, the_geom_webmercator FROM chriswhong.cpnv
    
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/cartodb.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script>
     var mainLayer;
@@ -147,7 +147,7 @@ WITH q AS (SELECT cartodb_id, the_geom_webmercator FROM chriswhong.cpnv
       zoom: 14
     });
 
-    L.tileLayer('http://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png',{
+    L.tileLayer('https://cartodb-basemaps-{s}.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png',{
       attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
     }).addTo(map);
 


### PR DESCRIPTION
Switching to CartoDB's Fastly HTTPS CDNs so that everything can load over
HTTPS without errors.

I use [HTTPS Everywhere](https://www.eff.org/https-everywhere), which forces HTTPS on GitHub pages. 